### PR TITLE
[Validator] MaxLengthValidator does not pass an invalidValue to addViolation

### DIFF
--- a/Constraints/MaxLengthValidator.php
+++ b/Constraints/MaxLengthValidator.php
@@ -54,7 +54,7 @@ class MaxLengthValidator extends ConstraintValidator
             $this->context->addViolation($constraint->message, array(
                 '{{ value }}' => $value,
                 '{{ limit }}' => $constraint->limit,
-            ), null, (int) $constraint->limit);
+            ), $value, (int) $constraint->limit);
         }
     }
 }


### PR DESCRIPTION
Fix for issue #4398 on symfony/symfony

https://github.com/symfony/symfony/issues/4398
