### PR TITLE
Add This field is missing RU translation

### DIFF
--- a/Resources/translations/validators.ru.xlf
+++ b/Resources/translations/validators.ru.xlf
@@ -214,6 +214,10 @@
                 <source>This collection should contain exactly {{ limit }} elements.</source>
                 <target>Эта коллекция должна содержать ровно {{ limit }} элемент.|Эта коллекция должна содержать ровно {{ limit }} элемента.|Эта коллекция должна содержать ровно {{ limit }} элементов.</target>
             </trans-unit>
+            <trans-unit id="57">
+                <source>This field is missing.</source>
+                <target>Это поле отсутствует.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
<source>This field is missing.</source>
Have no translation. Not exists in EN version too. Just forgot? 
Symfony\Component\Validator\Constraints\Collection()
public $missingFieldsMessage = 'This field is missing.';
