### PR TITLE
DateRange constraint

### DIFF
--- a/Constraints/DateRange.php
+++ b/Constraints/DateRange.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\Constraints\Range;
+
+/**
+ * @Annotation
+ *
+ * @api
+ *
+ * @author Alexander Volochnev <admin@toplimit.ru>
+ */
+class DateRange extends Range
+{
+    public $format         = "d/m/Y";
+    public $minMessage     = 'This date should be {{ limit }} or later.';
+    public $maxMessage     = 'This date should be {{ limit }} or earlier.';
+    public $invalidMessage = 'This value should be a valid date.';
+
+    public function __construct($options = null)
+    {
+        parent::__construct($options);
+
+        if (isset($options['format']) && null !== $options['format']) {
+            $this->format = $options['format'];
+        }
+
+        if (null !== $this->min) {
+            $this->min = \DateTime::createFromFormat($this->format, $this->min);
+        }
+
+        if (null !== $this->max) {
+            $this->max = \DateTime::createFromFormat($this->format, $this->max);
+        }
+    }
+}

--- a/Constraints/DateRangeValidator.php
+++ b/Constraints/DateRangeValidator.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Constraints;
+
+use Symfony\Component\Validator\ConstraintValidator;
+use Symfony\Component\Validator\Constraint;
+
+/**
+ * @author Alexander Volochnev <admin@toplimit.ru>
+ */
+class DateRangeValidator extends ConstraintValidator
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function validate($value, Constraint $constraint)
+    {
+        if (null === $value) {
+            return;
+        }
+
+        if (!$value instanceof \DateTime) {
+            $this->context->addViolation($constraint->invalidMessage);
+
+            return;
+        }
+
+        if (null !== $constraint->max && $value > $constraint->max) {
+            $this->context->addViolation($constraint->maxMessage, array(
+                '{{ value }}' => $value->format($constraint->format),
+                '{{ limit }}' => $constraint->max->format($constraint->format),
+            ));
+
+            return;
+        }
+
+        if (null !== $constraint->min && $value < $constraint->min) {
+            $this->context->addViolation($constraint->minMessage, array(
+                '{{ value }}' => $value->format($constraint->format),
+                '{{ limit }}' => $constraint->min->format($constraint->format),
+            ));
+        }
+    }
+}

--- a/Resources/translations/validators.en.xlf
+++ b/Resources/translations/validators.en.xlf
@@ -222,6 +222,18 @@
                 <source>Unsupported card type or invalid card number.</source>
                 <target>Unsupported card type or invalid card number.</target>
             </trans-unit>
+            <trans-unit id="59">
+                <source>This value should be a valid date.</source>
+                <target>This value should be a valid date.</target>
+            </trans-unit>
+            <trans-unit id="60">
+                <source>This date should be {{ limit }} or earlier.</source>
+                <target>This date should be {{ limit }} or earlier.</target>
+            </trans-unit>
+            <trans-unit id="61">
+                <source>This value should be {{ limit }} or later.</source>
+                <target>This value should be {{ limit }} or later.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/validators.ru.xlf
+++ b/Resources/translations/validators.ru.xlf
@@ -222,6 +222,18 @@
                 <source>Unsupported card type or invalid card number.</source>
                 <target>Неподдерживаемый тип или неверный номер карты.</target>
             </trans-unit>
+            <trans-unit id="59">
+                <source>This value should be a valid date.</source>
+                <target>Значение должно быть датой.</target>
+            </trans-unit>
+            <trans-unit id="60">
+                <source>This date should be {{ limit }} or earlier.</source>
+                <target>Дата должна быть {{ limit }} или ранее.</target>
+            </trans-unit>
+            <trans-unit id="61">
+                <source>This value should be {{ limit }} or later.</source>
+                <target>Дата должна быть {{ limit }} или позднее.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Added DateRange constraint and appropriate translations in russian and english. 

Date format by default is d/m/Y, but easily can be overriden by format property of constraint, f.e.:

``` php
    /**
     * @Assert\DateRange(
     *      min    = "01.01.1930",
     *      max    = "01.01.2012",
     *      format = "d.m.Y"
     * )
     */
    protected $birthday;
```

This is my first commit to symfony components so feel free to request any additionals - write docs, improve something or so on.
