### PR TITLE
[Validator] Fixed NotBlank with booleans

### DIFF
--- a/Constraints/NotBlankValidator.php
+++ b/Constraints/NotBlankValidator.php
@@ -26,7 +26,7 @@ class NotBlankValidator extends ConstraintValidator
      */
     public function validate($value, Constraint $constraint)
     {
-        if (false === $value || (empty($value) && '0' != $value)) {
+        if (false === $value || (empty($value) && '0' !== $value && false !== $value)) {
             $this->context->addViolation($constraint->message);
         }
     }


### PR DESCRIPTION
The following code resulted in an error:

``` php
class Foo
{
    /**
     * @Assert\Type("bool")
     * @Assert\NotBlank
     */
    public $foo;
}

$foo = new Foo;
$foo->foo = false;
$validator->validate($foo);
```

That's because `empty($value)` returns `true` when `$value` is `false` and it's not put in the exceptions.

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | - |
| License | MIT |
| Doc PR | - |
