### PR TITLE
Fix a validator translation

### DIFF
--- a/Resources/translations/validators.en.xlf
+++ b/Resources/translations/validators.en.xlf
@@ -175,8 +175,8 @@
                 <target>The image height is too small ({{ height }}px). Minimum height expected is {{ min_height }}px.</target>
             </trans-unit>
             <trans-unit id="47">
-                <source>This value should be the user current password.</source>
-                <target>This value should be the user current password.</target>
+                <source>This value should be the user's current password.</source>
+                <target>This value should be the user's current password.</target>
             </trans-unit>
             <trans-unit id="48">
                 <source>This value should have exactly {{ limit }} character.|This value should have exactly {{ limit }} characters.</source>


### PR DESCRIPTION
This validation message is not proper English.  I also fixed it in the validator, symfony/symfony#11382
