### PR TITLE
Add suport for non-ASCII chars in host when checking DNS records in email validation

### DIFF
--- a/Constraints/EmailValidator.php
+++ b/Constraints/EmailValidator.php
@@ -113,7 +113,7 @@ class EmailValidator extends ConstraintValidator
      */
     private function checkMX($host)
     {
-        return checkdnsrr($host, 'MX');
+        return checkdnsrr(idn_to_ascii($host), 'MX');
     }
 
     /**
@@ -125,6 +125,7 @@ class EmailValidator extends ConstraintValidator
      */
     private function checkHost($host)
     {
+        $host = idn_to_ascii($host);
         return $this->checkMX($host) || (checkdnsrr($host, "A") || checkdnsrr($host, "AAAA"));
     }
 }

--- a/Tests/Constraints/EmailValidatorTest.php
+++ b/Tests/Constraints/EmailValidatorTest.php
@@ -65,6 +65,7 @@ class EmailValidatorTest extends AbstractConstraintValidatorTest
             array('fabien@symfony.com'),
             array('example@example.co.uk'),
             array('fabien_potencier@example.fr'),
+            array('test@ñandu.cl'),
         );
     }
 


### PR DESCRIPTION
cf. http://php.net/manual/en/function.checkdnsrr.php#113537

Currently that host validation fails, but it is a valid one.