### PR TITLE
Fix validator failure with empty string

### DIFF
--- a/Constraints/UrlValidator.php
+++ b/Constraints/UrlValidator.php
@@ -48,7 +48,7 @@ class UrlValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, __NAMESPACE__.'\Url');
         }
 
-        if (null === $value || '' === $value) {
+        if (null === $value) {
             return;
         }
 
@@ -57,6 +57,10 @@ class UrlValidator extends ConstraintValidator
         }
 
         $value = (string) $value;
+        if ('' === $value) {
+            return;
+        }
+
         $pattern = sprintf(static::PATTERN, implode('|', $constraint->protocols));
 
         if (!preg_match($pattern, $value)) {


### PR DESCRIPTION
Fix validator failure if method `__toString` of passed object return an empty string.