### PR TITLE
Updated default German IBAN validation message

### DIFF
--- a/Resources/translations/validators.de.xlf
+++ b/Resources/translations/validators.de.xlf
@@ -224,7 +224,7 @@
             </trans-unit>
             <trans-unit id="59">
                 <source>This is not a valid International Bank Account Number (IBAN).</source>
-                <target>Dieser Wert ist keine gültige IBAN-Kontonummer.</target>
+                <target>Dieser Wert ist keine gültige internationale Bankkontonummer (IBAN).</target>
             </trans-unit>
             <trans-unit id="60">
                 <source>This value is not a valid ISBN-10.</source>


### PR DESCRIPTION
IBAN is an acronym. The term 'IBAN-Kontonummer' is redundant, since the 'AN' part (Account Number) already translates to 'Kontonummer'. It's like saying 'International Bank Account Number Account Number'.