### PR TITLE
Allowing to add custom loaders to Validator Builder

### DIFF
--- a/ValidatorBuilder.php
+++ b/ValidatorBuilder.php
@@ -25,6 +25,7 @@ use Symfony\Component\Validator\Mapping\Cache\CacheInterface;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
 use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 use Symfony\Component\Validator\Mapping\Loader\LoaderChain;
+use Symfony\Component\Validator\Mapping\Loader\LoaderInterface;
 use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
 use Symfony\Component\Validator\Mapping\Loader\XmlFileLoader;
 use Symfony\Component\Validator\Mapping\Loader\XmlFilesLoader;
@@ -58,6 +59,11 @@ class ValidatorBuilder implements ValidatorBuilderInterface
      * @var array
      */
     private $methodMappings = array();
+
+    /**
+     * @var LoaderInterface[]
+     */
+    private $loaders = array();
 
     /**
      * @var Reader|null
@@ -194,6 +200,16 @@ class ValidatorBuilder implements ValidatorBuilderInterface
         }
 
         $this->methodMappings = array_merge($this->methodMappings, $methodNames);
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addLoader(LoaderInterface $loader)
+    {
+        $this->loaders[] = $loader;
 
         return $this;
     }
@@ -351,6 +367,10 @@ class ValidatorBuilder implements ValidatorBuilderInterface
 
             foreach ($this->methodMappings as $methodName) {
                 $loaders[] = new StaticMethodLoader($methodName);
+            }
+
+            foreach ($this->loaders as $loader) {
+                $loaders[] = $loader;
             }
 
             if ($this->annotationReader) {

--- a/ValidatorBuilderInterface.php
+++ b/ValidatorBuilderInterface.php
@@ -15,6 +15,7 @@ use Doctrine\Common\Annotations\Reader;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\Translation\TranslatorInterface;
 use Symfony\Component\Validator\Mapping\Cache\CacheInterface;
+use Symfony\Component\Validator\Mapping\Loader\LoaderInterface;
 
 /**
  * A configurable builder for ValidatorInterface objects.
@@ -94,6 +95,15 @@ interface ValidatorBuilderInterface
      * @return ValidatorBuilderInterface The builder object
      */
     public function addMethodMappings(array $methodNames);
+
+    /**
+     * Adds a constraints loader to the validator.
+     *
+     * @param LoaderInterface $loader the loader instance
+     *
+     * @return ValidatorBuilderInterface The builder object
+     */
+    public function addLoader(LoaderInterface $loader);
 
     /**
      * Enables annotation based constraint mapping.


### PR DESCRIPTION
This is only to allow custom loaders, but...

In my humble opinion...

Instead of having the Builder to check for its KNOWN loaders (xmlMappings, yamlMappings, methodMappings or Doctrine's annotationReader), the builder should only know which loaders to use (even if shortcut methods are provided for simplicity).

XML configurations could look like:

```xml
<framework:config>
    <framework:validation cache="...">
        <framework:loader service="annotation_reader_loader" />
        <framework:loader service="custom_loader" />
        <!-- Any other loader to be used with its custom configuration format -->
    </framework:validation>
</framework:config>
```