### PR TITLE
fixing grammar error

### DIFF
--- a/Constraints/CollectionValidator.php
+++ b/Constraints/CollectionValidator.php
@@ -34,7 +34,7 @@ class CollectionValidator extends ConstraintValidator
         }
 
         if (!\is_array($value) && !($value instanceof \Traversable && $value instanceof \ArrayAccess)) {
-            throw new UnexpectedTypeException($value, 'array or Traversable and ArrayAccess');
+            throw new UnexpectedTypeException($value, 'array, Traversable or ArrayAccess');
         }
 
         // We need to keep the initialized context when CollectionValidator


### PR DESCRIPTION
Used or, instead of and in `Expected argument of type "array or Traversable and ArrayAccess"`

See issue https://github.com/symfony/symfony/issues/28073