### PR TITLE
WIP: Choice constraint improvement

### DIFF
--- a/Constraints/Choice.php
+++ b/Constraints/Choice.php
@@ -33,6 +33,7 @@ class Choice extends Constraint
 
     public $choices;
     public $callback;
+    public $choicesAsConstant;
     public $multiple = false;
     public $strict = true;
     public $min;


### PR DESCRIPTION
Hi,

here is a little improvement for the choice constraint: this would be nice to use an array constant as choices. This would prevent from creating a function for the only sake of using it as callback for this constraint.

BTW, another useful feature for this constraint would be to expose a new `choices` wildcard for the messages, in order to provide a way to display easily the valid choices to the user.

this is just a POC, i'll provide some test if this is behavior is validated.

thanks.