### PR TITLE
CallableValidator

### DIFF
--- a/Tests/Validator/CallableValidatorTest.php
+++ b/Tests/Validator/CallableValidatorTest.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\Validator\Tests\Validator;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Validator\Constraints\Email;
+use Symfony\Component\Validator\Constraints\Length;
+use Symfony\Component\Validator\Exception\LogicException;
+use Symfony\Component\Validator\Validator\CallableValidator;
+
+/**
+ * @author Jan Vernieuwe <jan.vernieuwe@phpro.be>
+ */
+class CallableValidatorTest extends TestCase
+{
+    public function testValidate()
+    {
+        $validator = new CallableValidator([new Length(['min' => 10]), new Email()]);
+        $this->assertEquals('test@example.com', $validator('test@example.com'));
+        $this->expectException(LogicException::class, 'Symfony\Component\Validator\Exception\LogicException : test:
+    This value is too short. It should have 10 characters or more. (code 9ff3fdc4-b214-49db-8718-39c315e33d45)
+test:
+    This value is not a valid email address. (code bd79c0ab-ddba-46cc-a703-a7a4b08de310)');
+        $validator('test');
+    }
+}

--- a/Validator/CallableValidator.php
+++ b/Validator/CallableValidator.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Symfony\Component\Validator\Validator;
+
+use Symfony\Component\Validator\Constraint;
+use Symfony\Component\Validator\Validation;
+use Symfony\Component\Validator\Exception\LogicException;
+
+/**
+ * Class that enables usage of the validators in console questions
+ *
+ * @author Jan Vernieuwe <jan.vernieuwe@phpro.be>
+ */
+class CallableValidator
+{
+    /**
+     * @var Constraint[]
+     */
+    private $constraints;
+
+    /**
+     * @var ValidatorInterface
+     */
+    private $validator;
+
+    /**
+     * CallableValidator constructor.
+     *
+     * @param Constraint[] $constraints
+     */
+    public function __construct(array $constraints)
+    {
+        $this->constraints = $constraints;
+        $this->validator = Validation::createValidator();
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return string|null
+     * @throws LogicException
+     */
+    public function __invoke(string $value = null): string
+    {
+        $violations = $this->validator->validate($value, $this->constraints);
+        if (0 !== $violations->count()) {
+            throw new LogicException((string)$violations);
+        }
+
+        return $value;
+    }
+}


### PR DESCRIPTION
In the latest symfony/console version, there is no more default validation, and all validation needs to be a callable (and afaik there are none provided by SF, please correct me if i'm wrong).
This little class allows you to easily use the Symfony Validators in console questions (or anywhere else that needs a callable validator)

Example use case:
```php
$io = new SymfonyStyle($input, $output);
$required = new CallableValidator([new NotBlank()]);
$wsdl = $io->ask('Wsdl location (URL or path to file)', null, $required);
```

This is just an initial PR to see if this is an idea you are willing to merge.
The implementation can still be changed, for example the exception message could probably be cleaner.