### PR TITLE
fix: RegexValidator doesn't validate empty strings anymore

### DIFF
--- a/Constraints/RegexValidator.php
+++ b/Constraints/RegexValidator.php
@@ -33,7 +33,7 @@ class RegexValidator extends ConstraintValidator
             throw new UnexpectedTypeException($constraint, Regex::class);
         }
 
-        if (null === $value || '' === $value) {
+        if (null === $value) {
             return;
         }
 


### PR DESCRIPTION
It is possible to pass an empty string as a `$pattern` to Regex() constraint, so it should be treated as a valid singular case, therefore Regex() should not consider empty strings via non-empty regexps as valid