### PR TITLE
fix: override of protected property from parent

### DIFF
--- a/Mapping/ClassMetadata.php
+++ b/Mapping/ClassMetadata.php
@@ -346,7 +346,7 @@ class ClassMetadata extends GenericMetadata implements ClassMetadataInterface
                     $constraint->addImplicitGroupName($this->getDefaultGroup());
                 }
 
-                if ($member instanceof MemberMetadata && !$member->isPrivate($this->name)) {
+                if ($member instanceof MemberMetadata && (!$member->isProtected($this->name) && !$member->isPrivate($this->name))) {
                     $property = $member->getPropertyName();
                     $this->members[$property] = [$member];
 


### PR DESCRIPTION
### Symfony version(s) affected

6.3 and above

### Description

During validation if we are using abstract base class with any Assert on property in it, and on child class we are overriding the property and Asserts current behaviour is enforcing the parent protected property Asserts. 

I.e.:

```

abstract class ParentClass
{
    public function __construct(
        #[Assert\NotNull]
        protected ?string $value    
    ) {
    }
}
class Child extends ParentClass
{
    public function __construct(
        #[Assert\Expression(expression: 'this.isValid() === true', message: 'value is invalid. ')]
        #[Assert\Length(min: 11, max: 11, exactMessage: 'must be 11 digits long')]
        #[Assert\NotBlank(message: 'value is required')]
        #[Assert\Regex(pattern: '/^[0-9]+$/', message: 'Must contain digits only')]
        protected ?string $value = null
    ) {}
}
```


### How to reproduce

To reproduce you will need validator, annotations and property access
```
composer require symfony/validator
```


example.php:
```php
<?php
// composer require symfony/validator
use Doctrine\Common\Annotations\AnnotationReader;
use PHPUnit\Framework\TestCase;
use Symfony\Component\Validator\ValidatorBuilder;

// parent abstract class
abstract class ParentClass
{
    public function __construct(
        #[Assert\NotNull]
        protected ?string $value    
    ) {
    }
}

// example child class
class Child extends ParentClass
{
    public function __construct(
        #[Assert\Expression(expression: 'this.isValid() === true', message: 'value is invalid. ')]
        #[Assert\Length(min: 11, max: 11, exactMessage: 'must be 11 digits long')]
        #[Assert\NotBlank(message: 'value is required')]
        #[Assert\Regex(pattern: '/^[0-9]+$/', message: 'Must contain digits only')]
        protected ?string $value = null
    ) {}
}

// example test case 
class ExampleTest extends TestCase
{
    /**
     * @dataProvider provideValues
     */
    public function testValidation(string $value, int $violationCount): void
    {
        $validatorBuilder = new ValidatorBuilder();
        $validatorBuilder->enableAnnotationMapping()
            ->setDoctrineAnnotationReader(new AnnotationReader());
        $validator = $validatorBuilder->getValidator();

        $child = new Child($value);

        $this->assertEquals($violationCount, $validator->validate($child)->count());
    }

    /**
     * @return array<int, string|int>[]
     */
    public function provideValues(): array
    {
        return [
            ['07127669600', 0],
            ['35424643507', 0],
            ['11144477735', 0],
            ['11144477734', 1],
            ['11144477725', 1],
            ['11111111111', 1],
            ['55555555555', 1],
            ['aaaaaaaaaaa', 1],
            ['           ', 1],
            ['071276696', 2],
        ];
    }
}

```

### Possible Solution

For the path in `\Symfony\Component\Validator\Mapping\ClassMetadata::mergeConstraints:349` handle not only private properties but also protected
in example:
```php
                if ($member instanceof MemberMetadata && (!$member->isProtected($this->name) && !$member->isPrivate($this->name))) {

```