### PR TITLE
Update validators.cs.xlf

### DIFF
--- a/Resources/translations/validators.cs.xlf
+++ b/Resources/translations/validators.cs.xlf
@@ -426,6 +426,10 @@
                <source>Using hidden overlay characters is not allowed.</source>
                <target>Použití skrytých překrývajících znaků není povoleno.</target>
            </trans-unit>
+           <trans-unit id="110">
+               <source>The extension of the file is invalid ({{ extension }}). Allowed extensions are {{ extensions }}.</source>
+               <target>Přípona souboru je neplatná ({{ extension }}). Povolené přípony jsou {{ extensions }}.</target>
+           </trans-unit>
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
I think it will be missing also in another languages and I think this won't be the only key from  `/vendor/symfony/validator/Constraints/File.php` which is missing. Not sure how these are generated but would be good to check this overall.