### PR TITLE
[#57677] Reintroduce setGroupProvider to AttributeLoader

### DIFF
--- a/Mapping/Loader/AttributeLoader.php
+++ b/Mapping/Loader/AttributeLoader.php
@@ -37,6 +37,7 @@ class AttributeLoader implements LoaderInterface
             if ($constraint instanceof GroupSequence) {
                 $metadata->setGroupSequence($constraint->groups);
             } elseif ($constraint instanceof GroupSequenceProvider) {
+                $metadata->setGroupProvider($constraint->provider);
                 $metadata->setGroupSequenceProvider(true);
             } elseif ($constraint instanceof Constraint) {
                 $metadata->addConstraint($constraint);

--- a/Tests/Mapping/Loader/AttributeLoaderTest.php
+++ b/Tests/Mapping/Loader/AttributeLoaderTest.php
@@ -210,6 +210,21 @@ class AttributeLoaderTest extends TestCase
         $this->assertEquals($expected, $metadata);
     }
 
+    public function testLoadExternalGroupSequenceProvider()
+    {
+        $loader = $this->createAttributeLoader();
+        $namespace = $this->getFixtureAttributeNamespace();
+
+        $metadata = new ClassMetadata($namespace.'\GroupProviderDto');
+        $loader->loadClassMetadata($metadata);
+
+        $expected = new ClassMetadata($namespace.'\GroupProviderDto');
+        $expected->setGroupSequenceProvider(true);
+        $expected->setGroupProvider('Symfony\Component\Validator\Tests\Dummy\DummyGroupProvider');
+
+        $this->assertEquals($expected, $metadata);
+    }
+
     protected function createAttributeLoader(): AttributeLoader
     {
         return new AttributeLoader();
@@ -218,5 +233,10 @@ class AttributeLoaderTest extends TestCase
     protected function getFixtureNamespace(): string
     {
         return 'Symfony\Component\Validator\Tests\Fixtures\NestedAttribute';
+    }
+
+    protected function getFixtureAttributeNamespace(): string
+    {
+        return 'Symfony\Component\Validator\Tests\Fixtures\Attribute';
     }
 }


### PR DESCRIPTION
Was introduced in AnnotationLoader and got removed during the 6.4->7.0 process. Fixes issue [#57677](https://github.com/symfony/symfony/issues/57677).